### PR TITLE
Automatic insertion of Button into Toobar Group = insert

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -27,6 +27,7 @@ CKEDITOR.plugins.add('uploadcare', {
         
         editor.ui.addButton('Uploadcare', {
             label : 'Uploadcare',
+            toolbar : 'insert',
             command : 'showUploadcareDialog',
             icon : this.path + 'images/logo.png'
         });       


### PR DESCRIPTION
Minor tweak to plugin.js to default the Uploadcare button to the "insert" toolbar group.
This allows the button to display, automatically.
