### PR TITLE
Bugfix: load widget just if it is not already loaded.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -6,11 +6,14 @@ CKEDITOR.plugins.add('uploadcare', {
   icons: 'uploadcare',
   init : function(editor) {
     var config = editor.config.uploadcare || {};
-    var version = config.widgetVersion || '1.2.3';
-    var widget_url = 'https://ucarecdn.com/widget/' + version +
-             '/uploadcare/uploadcare-' + version + '.min.js'
-    CKEDITOR.scriptLoader.load(widget_url);
 
+    // Check if Uploadcare is already loaded and load it if not.
+    if (typeof uploadcare === 'undefined') {
+        var version = config.widgetVersion || '1.2.3';
+        var widget_url = 'https://ucarecdn.com/widget/' + version +
+                 '/uploadcare/uploadcare-' + version + '.min.js'
+        CKEDITOR.scriptLoader.load(widget_url);
+    }
 
     // Apply default properties.
     if ( ! ('crop' in config)) {


### PR DESCRIPTION
I ran into this issue when I was trying to set file validation to all widgets in a page. As I was using widget in standalone and plugin ways, here's what happened:
1. Standalone plugin was loaded
2. File validation was set
3. CKEditor plugin reloaded widget with delay, resetting file validation

So we need to check for a loaded widget instance before load it blindly, right?

Hope it helps!
